### PR TITLE
Add support for shell script input/output paths

### DIFF
--- a/lib/xcake/dsl/build_phase/shell_script_build_phase.rb
+++ b/lib/xcake/dsl/build_phase/shell_script_build_phase.rb
@@ -8,6 +8,12 @@ module Xcake
     # String coataining the contents of the script to run
     attr_accessor :script
 
+    # input/output paths
+    attr_accessor :input_paths
+    attr_accessor :output_paths
+    attr_accessor :input_file_list_paths
+    attr_accessor :output_file_list_paths
+
     def build_phase_type
       Xcodeproj::Project::Object::PBXShellScriptBuildPhase
     end
@@ -15,6 +21,10 @@ module Xcake
     def configure_native_build_phase(native_build_phase, _context)
       native_build_phase.name = name
       native_build_phase.shell_script = script.strip_heredoc
+      native_build_phase.input_paths = input_paths || []
+      native_build_phase.output_paths = output_paths || []
+      native_build_phase.input_file_list_paths = input_file_list_paths || []
+      native_build_phase.output_file_list_paths = output_file_list_paths || []
     end
 
     def to_s

--- a/spec/dsl/build_phase/shell_script_build_phase_spec.rb
+++ b/spec/dsl/build_phase/shell_script_build_phase_spec.rb
@@ -15,6 +15,13 @@ module Xcake
 
       allow(@native_build_phase).to receive(:name=)
       allow(@native_build_phase).to receive(:shell_script=)
+
+      @paths = %w(path1 path2 path3 path4 path5).shuffle
+
+      allow(@native_build_phase).to receive(:input_paths=)
+      allow(@native_build_phase).to receive(:output_paths=)
+      allow(@native_build_phase).to receive(:input_file_list_paths=)
+      allow(@native_build_phase).to receive(:output_file_list_paths=)
     end
 
     it 'should use correct build phase type' do
@@ -29,6 +36,32 @@ module Xcake
     it 'should set script' do
       expect(@native_build_phase).to receive(:shell_script=).with(@script.strip_heredoc)
       @phase.configure_native_build_phase(@native_build_phase, nil)
+    end
+
+    context 'Input/Ouput paths' do
+      it 'should set input paths' do
+        @phase.input_paths = @paths
+        expect(@native_build_phase).to receive(:input_paths=).with(@paths)
+        @phase.configure_native_build_phase(@native_build_phase, nil)
+      end
+
+      it 'should set output paths' do
+        @phase.output_paths = @paths
+        expect(@native_build_phase).to receive(:output_paths=).with(@paths)
+        @phase.configure_native_build_phase(@native_build_phase, nil)
+      end
+
+      it 'should set input file list paths' do
+        @phase.input_file_list_paths = @paths
+        expect(@native_build_phase).to receive(:input_file_list_paths=).with(@paths)
+        @phase.configure_native_build_phase(@native_build_phase, nil)
+      end
+
+      it 'should set output file list paths' do
+        @phase.output_file_list_paths = @paths
+        expect(@native_build_phase).to receive(:output_file_list_paths=).with(@paths)
+        @phase.configure_native_build_phase(@native_build_phase, nil)
+      end
     end
   end
 end


### PR DESCRIPTION
This allows specifying input/output paths for shell script build phases like so:
```ruby
target.pre_shell_script_build_phase 'Script Name', 'script_path.sh' do |phase|
  phase.input_paths = ['input1', 'input2']
  phase.output_paths = ['output1', 'output2']
end
```

This saves time by not running the script when no necessary, more details [here](https://indiestack.com/2014/12/speeding-up-custom-script-phases/).