### PR TITLE
Add support for Siri Intents as source files

### DIFF
--- a/lib/xcake/path_classifier.rb
+++ b/lib/xcake/path_classifier.rb
@@ -7,7 +7,7 @@ module Xcake
     EXTENSION_MAPPINGS = {
       PBXFrameworksBuildPhase: %w(.a .dylib .so .framework).freeze,
       PBXHeadersBuildPhase: %w(.h .hpp).freeze,
-      PBXSourcesBuildPhase: %w(.c .m .mm .cpp .swift .xcdatamodeld .java).freeze,
+      PBXSourcesBuildPhase: %w(.c .m .mm .cpp .swift .xcdatamodeld .java .intentdefinition).freeze,
       PBXResourcesBuildPhase: %w(.xcassets).freeze
     }.freeze
 


### PR DESCRIPTION
This PR adds support for Siri Intents as source files. Previously, they were handled as resource files, but that prevented Xcode from generating intent classes, causing projects that rely on them to fail to build.