### PR TITLE
Add .cc to PBXSourcesBuildPhase

### DIFF
--- a/lib/xcake/path_classifier.rb
+++ b/lib/xcake/path_classifier.rb
@@ -7,7 +7,7 @@ module Xcake
     EXTENSION_MAPPINGS = {
       PBXFrameworksBuildPhase: %w(.a .dylib .so .framework).freeze,
       PBXHeadersBuildPhase: %w(.h .hpp).freeze,
-      PBXSourcesBuildPhase: %w(.c .m .mm .cpp .swift .xcdatamodeld .java).freeze,
+      PBXSourcesBuildPhase: %w(.c .m .mm .cpp .cc .swift .xcdatamodeld .java).freeze,
       PBXResourcesBuildPhase: %w(.xcassets).freeze
     }.freeze
 


### PR DESCRIPTION
Some C++ projects use .cc for source files instead of .cpp.