### PR TITLE
Make ClassDescendants behave deterministically

### DIFF
--- a/lib/xcake/core_ext/class.rb
+++ b/lib/xcake/core_ext/class.rb
@@ -7,7 +7,7 @@ module Xcake
       # Returns all descendants of a class
       #
       def descendants
-        ObjectSpace.each_object(singleton_class).select { |klass| klass < self }
+        ObjectSpace.each_object(singleton_class).select { |klass| klass < self }.sort_by(&:to_s)
       end
     end
   end


### PR DESCRIPTION
Sort descendants by class name.  This ensures that generators are run in a deterministic order.

(With this, plus changes to `xcodeproj`, plus manually calling `predictabilize_uuids` in my Cakefile, I can get the same project.pbxproj output across multiple runs.)