### PR TITLE
Remove reliance on ActiveSupport

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -5,14 +5,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-10.15]
-        ruby: [2.3.3, 2.4, 2.5, 2.6, 2.7]
+        ruby: [2.6, 2.7]
         gemfile: [Gemfile]
         include:
           - os: ubuntu-latest
-            ruby: 2.3.3
+            ruby: 2.6
             gemfile: gemfiles/Gemfile.xcodeproj-edge
           - os: macos-10.15
-            ruby: 2.3.3
+            ruby: 2.6
             gemfile: gemfiles/Gemfile.xcodeproj-edge
     runs-on: ${{ matrix.os }}
     env:

--- a/lib/xcake/constants.rb
+++ b/lib/xcake/constants.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/hash/deep_merge'
+require 'deep_merge'
 
 module Xcake
   module Constants

--- a/xcake.gemspec
+++ b/xcake.gemspec
@@ -19,16 +19,15 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = %w(xcake)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3.3'
-
-  spec.add_dependency 'claide', '< 2.0', '>= 0.9.1'
-  spec.add_dependency 'cork'
-  spec.add_dependency 'deep_merge'
-  spec.add_dependency 'hooks', '~> 0.4.1'
-  spec.add_dependency 'xcodeproj', '< 2.0.0', '>= 1.3.0'
+  spec.required_ruby_version = '>= 2.6'
 
   # Lock `activesupport` (transitive dependency via `xcodeproj`) to keep supporting system ruby
-  spec.add_dependency 'activesupport', '< 6'
+  spec.add_runtime_dependency 'activesupport', '< 6'
+  spec.add_runtime_dependency 'claide', '< 2.0', '>= 0.9.1'
+  spec.add_runtime_dependency 'cork'
+  spec.add_runtime_dependency 'deep_merge'
+  spec.add_runtime_dependency 'hooks', '~> 0.4.1'
+  spec.add_runtime_dependency 'xcodeproj', '< 2.0.0', '>= 1.3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.10'
   spec.add_development_dependency 'os', '~> 1.0'

--- a/xcake.gemspec
+++ b/xcake.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.required_ruby_version = '>= 2.6'
 
-  # Lock `activesupport` (transitive dependency via `xcodeproj`) to keep supporting system ruby
-  spec.add_runtime_dependency 'activesupport', '< 6'
   spec.add_runtime_dependency 'claide', '< 2.0', '>= 0.9.1'
   spec.add_runtime_dependency 'cork'
   spec.add_runtime_dependency 'deep_merge'


### PR DESCRIPTION
Turns out the entire repo wasn't actually using `ActiveSupport` anymore.  
This PR removes the dependency from the gemspec, and also bumps minimum supported Ruby version to 2.6 (macOS system Ruby is 2.6.3 now).